### PR TITLE
Travis CI now run also on php 7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,15 @@ php:
   - 5.6
   - 7.0
   - 7.1
+  - 7.2
+  - nightly
   - hhvm
+
+matrix:
+  fast_finish: true
+  allow_failures:
+    - php: nightly
+
 install: composer install
 script: ./vendor/bin/phpunit --coverage-clover clover.xml
 after_success: sh -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then ./vendor/bin/coveralls -v; fi'


### PR DESCRIPTION
Fixes #6 

Travis CI now also run on PHP 7.2.
I also add PHP last buid(allowed failure)
